### PR TITLE
Incorrect date for "GSOC, The last commit 213c6f"

### DIFF
--- a/content/posts/gsoc-the-last-commit.md
+++ b/content/posts/gsoc-the-last-commit.md
@@ -1,5 +1,5 @@
 +++
-date = "2015-08-25T13:13:29+02:00"
+date = "2016-08-25T13:13:29+02:00"
 draft = false
 title = "GSOC, The last commit 213c6f"
 slug = "GSOC-The-last-commit-213c6f"


### PR DESCRIPTION
The post "GSOC, The last commit 213c6f" has incorrect date so it has not been shown in last posts. I'm not sute that I set the correct date, but it is exactle close to the one.