### PR TITLE
Fixed image links

### DIFF
--- a/content/posts/ascii-graphs.md
+++ b/content/posts/ascii-graphs.md
@@ -7,7 +7,7 @@ aliases = [
 	"ascii-graphs"
 ]
 +++
-![graph](/images/2014/Apr/Screenshot-2014-04-29-01-51-31.png)
+![graph](/images/Screenshot-2014-04-29-01-51-31.png)
 
 We may not have a GUI like IDA, but we still have some graphs. This is a small (200 lines of code) proof of concept, but there is more to come
 
@@ -20,6 +20,6 @@ We may not have a GUI like IDA, but we still have some graphs. This is a small (
 
 You can try this new feature with `VV` if you are using [radare2 from git]( https://github.com/radare/radare2/ ).
 
-![better graph](/images/2014/Apr/BmWvHyyIcAAoIfo-png-large.png)
+![better graph](/images/BmWvHyyIcAAoIfo-png-large.png)
 
 And by the way, this is documented, and has some  tests to avoid regressions. Feel free to take a look at the [/libr/cons]( https://github.com/radare/radare2/tree/master/libr/cons ) folder if you want to contribute.

--- a/content/posts/binary-diffing.md
+++ b/content/posts/binary-diffing.md
@@ -53,7 +53,7 @@ And now the cool feature : radare2 supports graph-diffing, à la [DarunGrim]( ht
 For example, `radiff2 -g main /bin/true  /bin/false | xdot -` will show the differences between the main function of `true` and `false`. You can compare it to `radiff2 -g main /bin/false /bin/true` (Notice the order of the arguments) to get the two versions.
 
 This is the result:
-![/bin/true and /bin/false graph diff](/images/2014/Aug/true_false.png)
+![/bin/true and /bin/false graph diff](/images/true_false.png)
 
 The parts in yellow are indicating that some offsets are not matching, the grey one is a perfect match, while the red one highlight a strong difference. If you look closely, you'll see that the left one is `mov edi, 0x1; call sym.imp.exit`, while the right one is `xor edi, edi; call sym.imp.exit`.
 

--- a/content/posts/countries.md
+++ b/content/posts/countries.md
@@ -9,13 +9,13 @@ aliases = [
 +++
 A couple of weeks ago, we did some _aggressive advertisement_ for the [RSoC]( http://rada.re/rsoc). Time to take a look at the results.
 
-![origin](/images/2014/May/Screenshot-2014-04-30-01-27-07.png)
+![origin](/images/Screenshot-2014-04-30-01-27-07.png)
 It seems that xvilka's [post]( http://habrahabr.ru/post/218969/ ) on habrahabr attracted many peoples, then comes reddit and [twitter]( https://twitter.com/radareorg ). The lobbying on [stackexchange]( https://reverseengineering.stackexchange.com/questions/tagged/radare2 ) is starting to pay.
 
 Most people are landing on the main page, and the second most viewed is the [crowfunding]( http://rada.re/y/?p=cowfunding ) one.
-![origin](/images/2014/May/Screenshot-2014-04-30-01-29-30.png)
+![origin](/images/Screenshot-2014-04-30-01-29-30.png)
 
 
 Unsurprisingly, our main visitor base is from Russia and USA. Followed by France, Germany and Spain. This is also where the main contributors are currently living; it seems that radare2 is contagious!
 
-![visitors](/images/2014/May/Screenshot-2014-04-30-01-32-15.png)
+![visitors](/images/Screenshot-2014-04-30-01-32-15.png)

--- a/content/posts/google-summer-of-code-2015.md
+++ b/content/posts/google-summer-of-code-2015.md
@@ -9,7 +9,7 @@ aliases = [
 +++
 We have applied to be a mentoring organization for this year’s [Google Summer of Code]( http://www.google-melange.com/gsoc/homepage/google/gsoc2015 ).
 
-![Google Summer of Code logo](/images/2015/Feb/gsoc.png)
+![Google Summer of Code logo](/images/gsoc.png)
 
 We recognize that GSoC is always a fierce competition, but we are, as ever, hopeful that we will join many other fine organizations in a great summer of hacking. If you are a student interested in applying, please head over to our [ideas page]( http://rada.re/gsoc ) and begin thinking about what you might like to hack on. Furthermore, we have several [low-hanging fruits]( https://github.com/radare/radare2/issues?q=is%3Aopen+label%3Aeasy ) if you want to play a bit with the codebase.
 

--- a/content/posts/initial-ascii-art-graph-layout.md
+++ b/content/posts/initial-ascii-art-graph-layout.md
@@ -19,4 +19,4 @@ Additionally the `?` key in `VV` (visual graph) view now shows the help message 
 
 Here is a cool screenshot:
 
-![img](/images/2014/May/VeCMo1r.png)
+![img](/images/VeCMo1r.png)

--- a/content/posts/interview-of-ret2libc.md
+++ b/content/posts/interview-of-ret2libc.md
@@ -77,8 +77,8 @@ Almost one month since our last article, time flees. This article is an intervie
 - Screenshots ?
 
 
-![Graph example](/images/2015/07/full.png)
+![Graph example](/images/full.png)
 *Example of graph*
 
-![Disasm in graph](/images/2015/07/disasm.png)
+![Disasm in graph](/images/disasm.png)
 *Disassembly in graph, without colours (yet)*

--- a/content/posts/making-coverity-happy.md
+++ b/content/posts/making-coverity-happy.md
@@ -9,6 +9,6 @@ aliases = [
 +++
 We are currently using [Coverity]( coverity.com ) to spot bugs and issues. During the last week, *jvoisin* and *xvilka* went full berzerk and killed more than a hundret of bugs, also helped by the usual contributors.
 
-![happy coverity](/images/2014/May/coverifix.jpg)
+![happy coverity](/images/coverifix.jpg)
 
 Feel free to help us and enter our one-fix-a-day contest!

--- a/content/posts/radare-0-9-8.md
+++ b/content/posts/radare-0-9-8.md
@@ -38,7 +38,7 @@ r2-0.9.8 now builds for [Android L]( https://en.wikipedia.org/wiki/Android_Lolli
 * Android mips64
 * Android aarch64
 
-![android screenshot](/images/2014/Nov/adroid.jpg)
+![android screenshot](/images/adroid.jpg)
 
 Also, we are now supporting crosscompilation for iOS devices. No need to use jailbroken devices as main builders. The `sys/ios-sdk.sh` script supports the very latest XCode from Yosemite.
 
@@ -60,7 +60,7 @@ We're now supporting:
 
 ## Better Debugger
 
-![debugger](/images/2014/Nov/regstacklisting.png)
+![debugger](/images/regstacklisting.png)
 
 Also, we have reworked on w32 to make the native debugger work again and support hardware breakpoint registers on x86. (thanks Skuater!)
 
@@ -73,7 +73,7 @@ Bear in mind that GDB is a totally fucked up protocol with lot of incompatibilit
 ## SDB integration
 [SDB]( https://github.com/radare/sdb ) is our key-value database system, that we're integrating into radare2. This simplifies the code, and increases the performances in many areas.
 
-![SDB](/images/2014/Nov/sdb.png)
+![SDB](/images/sdb.png)
 
 You can play around with SDB using the `k` commands.
 
@@ -91,12 +91,12 @@ The R_IO layer have been heavily tested, reviewed and partly rewritten to be mor
 
 
 ## DWARF
-![](/images/2014/Nov/dwarf.png)
+![](/images/dwarf.png)
 Montekki spent some time to add support for [DWARF]( http://dwarfstd.org/ )! Now you can debug your favourite ELF binary (almost) without reading assembly! 
 
 ## ESIL
 [ESIL]( https://github.com/radare/radare2/wiki/ESIL ) stands for *Evaluable Strings Intermedate Language*. It aims to describe a Forth-like representation for every opcode; the goal within radare being emulation, in order to improve the analysis.
-![](/images/2014/Nov/esil.png)
+![](/images/esil.png)
 
 With ESIL it is now possible to:
 
@@ -109,7 +109,7 @@ With ESIL it is now possible to:
 We will continue to enhance the ESIL support to  emulate code in a better fashion, and we plan to use it for injecting code on child processes and more.
 
 # Exploitation
-![pop pop ret](/images/2014/Nov/rop_pwn1.png)
+![pop pop ret](/images/rop_pwn1.png)
 - Analyze an specific memory address with `ai`
 - Take references from registers and memory with `drr/pxr` (*à la* PEDA)
 - ROP gadget searcher (`/R`)
@@ -120,7 +120,7 @@ We will continue to enhance the ESIL support to  emulate code in a better fashio
 ## ASCII art graphs
 Spawned by default when pressing `V` inside the *Visual mode* when placing the cursor on an already analized function. For callgraphs use `VVV`.
 
-![graph](/images/2014/Nov/Screenshot-2014-04-29-01-51-31.png)
+![graph](/images/Screenshot-2014-04-29-01-51-31.png)
 
 Graphviz, JSON and HTML5 interactive graphs are still supported, but not used by default.
 
@@ -135,7 +135,7 @@ We will soon release another post explaining all the details of the finalized RS
 
 ### Structures support
 [Skia]( http://libskia.so/ ) did great to implement structures support, a bit *à la* 010Editor.
-![structure](/images/2014/Nov/687474703a2f2f7777772e6c6962736b69612e736f2f7075622f72322532306c696e6b65642532306c6973742e706e67.png)
+![structure](/images/687474703a2f2f7777772e6c6962736b69612e736f2f7075622f72322532306c696e6b65642532306c6973742e706e67.png)
 
 Now with `r2 -nn` it is possible to analyze the file header structs using the `pf.`, `pxa` and other related commands.
 
@@ -197,17 +197,17 @@ Since we're a bunch of nice people, we also implemented:
 
 # Screenshots!
 
-![colourscheme](/images/2014/Nov/B0IyY38CcAIzxdy.png)
+![colourscheme](/images/B0IyY38CcAIzxdy.png)
 A new colourscheme
 
-![pxa](/images/2014/Nov/meh.jpg)
+![pxa](/images/meh.jpg)
 Coloured hexdump
 
-![Gameby patching](/images/2014/Nov/gb.png)
+![Gameby patching](/images/gb.png)
 Because patching Gameboy ROM with radare2 is fun!
 
-![Demangling](/images/2014/Nov/demangling.jpg)
+![Demangling](/images/demangling.jpg)
 Prototype of demangling
 
-![sonare](/images/2014/Nov/sonare.png)
+![sonare](/images/sonare.png)
 First screenshot of [sonare]( https://github.com/sapir/sonare ), a Qt-based disassembly viewer based on radare2.

--- a/content/posts/reverse-biosuefi-with-radare2.md
+++ b/content/posts/reverse-biosuefi-with-radare2.md
@@ -26,7 +26,7 @@ In order to modify a binary, radare2 must open the file in a writing mode using 
 
 Using seek `s` to move around the binary, wx to insert/write some hexadecimal: `wx 9090` for example, writes two `nop` and `wa` to assemble and write the opcodes: `wa push ebp` for example.
 
-![wx and wa](/images/2015/08/wxwa-1.png)
+![wx and wa](/images/wxwa-1.png)
 
 ### Using Visual mode
 
@@ -36,32 +36,32 @@ The Visual Mode is the best way to patch assembly or hexadecimal. It is similar 
 
 First let's patch the binary using hexadecimal patching. First go to the Visual hexadecimal panel:
 
-![Visual Mode](/images/2015/08/V.png)
+![Visual Mode](/images/V.png)
 
 Then activate the cursor selection: `c`. You can now select hexadecimal or ASCII representation using `tab` (notice the white border).
 
-![Cursor mode](/images/2015/08/Vc.png)
+![Cursor mode](/images/Vc.png)
 
 You can now insert hexadecimal code or string by typing `i`.
 
-![Insert String](/images/2015/08/Vcadd.png)
+![Insert String](/images/Vcadd.png)
 
 #### Opcode patching and Visual assembler
 
 Now let switch to the disassembly panel in visual mode (Vpp).
 
-![Visual Mode: Disassembly mode](/images/2015/08/VisualDisassembly.png)
+![Visual Mode: Disassembly mode](/images/VisualDisassembly.png)
 
 Like the hexadecimal view, you can enable the cursor mode using `c` and select opcodes you want to replace.
 
-![Cursor mode in Disassembly](/images/2015/08/Vcc.png)
+![Cursor mode in Disassembly](/images/Vcc.png)
 
 To change the `push ebp` for example by `xor eax, eax` opcode you can use `a`:
 
-![Va](/images/2015/08/Va.png)
+![Va](/images/Va.png)
 
 Visual mode also contain an interesting live preview Opcode patching: the Visual Assembler `A`.
 
 Let's replace this `xor eax,eax` by a `jmp 0x08048376`, notice the arrow on the left (==Live preview==).
 
-![Visual Assembler](/images/2015/08/VA.png)
+![Visual Assembler](/images/VA.png)

--- a/content/posts/rsoc-2015.md
+++ b/content/posts/rsoc-2015.md
@@ -15,6 +15,6 @@ Of course, if would have been great to be accepted by Google. Their program has 
 
 However, this situation also has advantages: we accept everyone, not only students, we don't have country-based restrictions, and we don't have strict deadlines: if you want to work a bit less, or a bit more, this is not an issue; we're flexible on everything.
 
-![RSoC](/images/2015/Mar/rsoc.jpg)
+![RSoC](/images/rsoc.jpg)
 
 So, stay tuned, you'll hear about our RSoC soon, we promise!

--- a/content/posts/solving-at-gunpoint-from-hack-lu-2014-with-radare2.md
+++ b/content/posts/solving-at-gunpoint-from-hack-lu-2014-with-radare2.md
@@ -27,11 +27,11 @@ gunpoint_2daf5fe3fb236b398ff9e5705a058a7f.dat: Gameboy ROM: "FLUX", [ROM ONLY], 
 
 So it is a Gameboy ROM. I load it up in [VisualBoyAdvance]( http://sourceforge.net/projects/vba/ ) and see what the game is.
 
-![running_game_1.png](/images/2014/Oct/pVD3Je8-1.png)
+![running_game_1.png](/images/pVD3Je8-1.png)
 
 It is a static image, and after some time, we receive this text.
 
-![running_game_2.png](/images/2014/Oct/meh.png)
+![running_game_2.png](/images/meh.png)
 
 Looks like we will have to put in some inputs from the joypad to get the flag. It is a crackme style but for the Gameboy! Sounds fun.
 
@@ -434,7 +434,7 @@ And we get a nice graph like this.  I have some annotations on mine, from revers
 
 type structure, which makes sense for value and index checking.
 
-![biggraph.png](/images/2014/Oct/bg.png)
+![biggraph.png](/images/bg.png)
 
 So, after some analysis, and guessing, we can figure the following. There is some debouncing/not expected to be perfect for clock cycles for button presses, so there must be tolerance for `0xFF00` to be the same for multiple cycles, or to be 0 with no penalty.
 
@@ -535,7 +535,7 @@ $10 - A                 $1 - Right
 
 Plug it in to VisualBoyAdvance and grab our 200 points!
 
-![win.png](/images/2014/Oct/win.png)
+![win.png](/images/win.png)
 
 Thanks to FluxFingers for a great CTF!
 

--- a/content/posts/solving-int3rupted-from-defcon-2015-qualifier-with-r2.md
+++ b/content/posts/solving-int3rupted-from-defcon-2015-qualifier-with-r2.md
@@ -42,7 +42,7 @@ impactsite ~ » cat /usr/lib/ldscripts/elf_x86_64.x | grep SEGMENT_START
   . = SEGMENT_START("ldata-segment", .);
 ```
 
-![header](/images/2015/06/elf_header.png)
+![header](/images/elf_header.png)
 
 Although it is a tedious process, you can dump the enough of the binary to load it up in your favorite disassembler.
 
@@ -57,19 +57,19 @@ So, quickly after reversing (which I will leave as an exercise to the reader), a
 
 Let's look at how int3rupted reads in the user's input. The function takes in a length, a fd to read from, a buffer to write to, and a "stop" character (newline).
 
-![read_user_input](/images/2015/06/disasm.png)
+![read_user_input](/images/disasm.png)
 
 Oh, what's this?!? The "length" var is increased, but it's termination value is at `length == 0`. This means we have an _unchecked_ read.
 
 Let's have a look at who else calls the `read_user_input` function.
 
-![xrefs](/images/2015/06/pd2.png)
+![xrefs](/images/pd2.png)
 
 Can it really be so simple, just a basic stack smash from `main_menu`? There is no `system` called in the binary, and there is *ASLR* activated, but if you recall, we have an arbitrary read, so we can just leak the addresses of libc functions, simple! There isn't even a stack canary to worry about.
 
 Let's use `rabin2` to find the address to read in order to leak the libc function `puts`.
 
-![puts](/images/2015/06/rabin.png)
+![puts](/images/rabin.png)
 
 Let's just assume that it's on Ubuntu trusty, because all of the other challenges were. Otherwise there are some nice [database tools]( https://github.com/niklasb/libc-database ) to use.
 
@@ -83,7 +83,7 @@ So, from here, there is not much left to do. Just construct an exploit that does
 Simple, right?
 
 And like magic, we can get a shell! 5 easy points. The final exploit below has comments for the r2 commands to get the needed values (like rop gadgets and offsets).
-![shell](/images/2015/06/shell.png)
+![shell](/images/shell.png)
 
 ```ruby
 #!/usr/bin/env ruby

--- a/content/posts/the-new-web-interface.md
+++ b/content/posts/the-new-web-interface.md
@@ -14,7 +14,7 @@ Lets highlight the new features:
 # Graphing
 The web-interface is now using [viz.js]( https://github.com/mdaines/viz.js/ ) to show interractive graphs, and the disassembly has now syntax highlighting, like the command line interface. When we say Interractive, we mean that you can not only move the graph, but also modify, edit and annotate it.
     
-![shortcuts](/images/2014/Dec/kkjXu31.png)
+![shortcuts](/images/kkjXu31.png)
 
 # IDA shortcuts
 Afficionados of IDA shouldn't be lost anymore, since the web-interface now shares a lot of its shortcuts:
@@ -31,6 +31,6 @@ You can now see hexdump, graph view, disassembly, settings and strings since eac
 
 By the way, changes made within the web interface are persistent, this means that you can build your colourscheme in an interractive manner. nOf course, every useful information that can be used to move in the binary can be displayed in the side bar, like functions, sections, imports, relocs, and flags.
 
-![colour selector](/images/2014/Dec/SmAmHLD.png)
+![colour selector](/images/SmAmHLD.png)
 
 Since everything is not doable within the web interface (yet), you'll find a command-line widget at the bottom of your screen, and the changes are propagated in real-time.

--- a/content/posts/the-rsoc-is-over.md
+++ b/content/posts/the-rsoc-is-over.md
@@ -21,7 +21,7 @@ We'd like to congratulate our 3 volunteers for their hard work and dedication. T
 
 ### Structures support
 [Skia]( http://libskia.so/ ) did great to implement structures support, a bit *à la* 010Editor.
-![structure](/images/2014/Nov/687474703a2f2f7777772e6c6962736b69612e736f2f7075622f72322532306c696e6b65642532306c6973742e706e67.png)
+![structure](/images/687474703a2f2f7777772e6c6962736b69612e736f2f7075622f72322532306c696e6b65642532306c6973742e706e67.png)
 Now with `r2 -nn` it is possible to analyze the file header structs using the `pf.`, `pxa` and other related commands.
 
 ```

--- a/content/posts/update-from-the-gsoc.md
+++ b/content/posts/update-from-the-gsoc.md
@@ -11,7 +11,7 @@ As you know, we have 2 students working on r2 for the [Google Summer of Code]( h
 
 As we're 3 weeks into the Summer, here's what one of our student, [sushant94]( https://github.com/sushant94 ) has to say about what he's been working on!
 
-![GSoC logo](/images/2015/06/gsoc2015-300x270.jpg)
+![GSoC logo](/images/gsoc2015-300x270.jpg)
 
 It's been three weeks into GSoC and I'm having an amazing time. I am working along side [dkreuter](https://twitter.com/dkreuter_) and been learning tons from him too!
 


### PR DESCRIPTION
Radare blog posts that had images missing should get them back.

Command used to fix is:
```
sed -i -r "s%\(/images/[^)]*/([^)]*)\)%(/images/\1)%g" *.md
```